### PR TITLE
#63 imagemagickがdockerコンテナに不要なため削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.1.3
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev imagemagick libvips
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev libvips
 RUN mkdir /pinspot
 WORKDIR /pinspot
 COPY Gemfile /pinspot/Gemfile


### PR DESCRIPTION
close #63 