### PR TITLE
#445 Factory_botのメソッドを使用する際に、クラス名の指定を省略できるようにするため

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,4 +60,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
close #445 