### PR TITLE
#487 users::registrationsコントローラのdestoroyアクションで、ensure_normal_userメソッドが実行されたときのrequest specを実装

### DIFF
--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -8,6 +8,48 @@ RSpec.describe "Users::Registrations", type: :request do
     end
   end
 
+  describe 'DELETE /users' do
+    context 'ゲストユーザー以外を削除した場合' do
+      let(:current_user) { create(:user) }
+
+      before do
+        sign_in current_user
+      end
+
+      it 'レスポンスコード303を返すこと' do
+        delete user_registration_path
+        expect(response).to have_http_status(303)
+      end
+    end
+
+    context 'ゲストユーザーを削除した場合' do
+      let(:guest_user) { User.guest }
+
+      before do
+        sign_in guest_user
+      end
+
+      it 'レスポンスコード302を返すこと' do
+        delete user_registration_path
+        expect(response).to have_http_status(302)
+      end
+
+      it 'ゲストユーザーを削除しないこと' do
+        expect { delete(user_registration_path) }.to change { User.count }.by(0)
+      end
+
+      it '「ゲストユーザーは削除できません」を表示すること' do
+        delete user_registration_path
+        expect(flash[:alert]).to eq 'ゲストユーザーは削除できません'
+      end
+
+      it 'トップページへリダイレクトすること' do
+        delete user_registration_path
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+
   describe 'GET /users/show' do
     context '正常な場合' do
       let(:current_user) { create(:user) }


### PR DESCRIPTION
close #487 