### PR TITLE
#489 users::registrationsコントローラのcreateアクションで、configure_permitted_parametersメソッドが実行されたときのrequest specを実装

### DIFF
--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -8,6 +8,100 @@ RSpec.describe "Users::Registrations", type: :request do
     end
   end
 
+  describe 'POST /users' do
+    context 'パラメータでprofileのnameが送られてきた場合' do
+      it 'レスポンスコード303を返すこと' do
+        post user_registration_path,
+        :params => {
+          :user => {
+            :profile_attributes => { name: Faker::Internet.username },
+            :email => Faker::Internet.email, :password => 'testtest',
+            :password_confirmation => 'testtest',
+          },
+        }
+        expect(response).to have_http_status(303)
+      end
+
+      it 'profileを作成すること' do
+        expect do
+          post user_registration_path,
+          :params => {
+            :user => {
+              :profile_attributes => { name: Faker::Internet.username },
+              :email => Faker::Internet.email, :password => 'testtest',
+              :password_confirmation => 'testtest',
+            },
+          }
+        end .to change { Profile.count }.by(1)
+      end
+
+      it 'userを作成すること' do
+        expect do
+          post user_registration_path,
+          :params => {
+            :user => {
+              :profile_attributes => { name: Faker::Internet.username },
+              :email => Faker::Internet.email, :password => 'testtest',
+              :password_confirmation => 'testtest',
+            },
+          }
+        end .to change { User.count }.by(1)
+      end
+    end
+
+    context 'パラメータでprofileのnameが送られてこない場合' do
+      it 'レスポンスコード422を返すこと' do
+        post user_registration_path,
+        :params => {
+          :user => {
+            :profile_attributes => { name: nil },
+            :email => Faker::Internet.email, :password => 'testtest',
+            :password_confirmation => 'testtest',
+          },
+        }
+        expect(response).to have_http_status(422)
+      end
+
+      it 'profileを作成しないこと' do
+        expect do
+          post user_registration_path,
+          :params => {
+            :user => {
+              :profile_attributes => { name: nil },
+              :email => Faker::Internet.email, :password => 'testtest',
+              :password_confirmation => 'testtest',
+            },
+          }
+        end.to change { Profile.count }.by(0)
+      end
+
+      it 'userを作成しないこと' do
+        expect do
+          post user_registration_path,
+          :params => {
+            :user => {
+              :profile_attributes => { name: nil },
+              :email => Faker::Internet.email, :password => 'testtest',
+              :password_confirmation => 'testtest',
+            },
+          }
+        end .to change { User.count }.by(0)
+      end
+
+      it 'エラーを表示すること' do
+        post user_registration_path,
+        :params => {
+          :user => {
+            :profile_attributes => { name: nil },
+            :email => Faker::Internet.email, :password => 'testtest',
+            :password_confirmation => 'testtest',
+          },
+        }
+        expect(response.body).to include 'エラー'
+      end
+    end
+  end
+
   describe 'DELETE /users' do
     context 'ゲストユーザー以外を削除した場合' do
       let(:current_user) { create(:user) }


### PR DESCRIPTION
close #489 