### PR TITLE
#500 コードの可読性が落ちるため、rspecのbeforeブロックでhttpリクエストを実装せず、example内で実装

### DIFF
--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -3,15 +3,14 @@ require 'rails_helper'
 RSpec.describe "Homes", type: :request do
   describe 'GET /' do
     let!(:post) { create(:post) }
-    before do
-      get root_path
-    end
 
     it '正常なレスポンスを返すこと' do
+      get root_path
       expect(response).to have_http_status(:success)
     end
 
     it '投稿名を表示すること' do
+      get root_path
       expect(response.body).to include post.title
     end
   end


### PR DESCRIPTION
close #500 